### PR TITLE
Update ExperienceSystem.cs

### DIFF
--- a/Systems/ExperienceSystem.cs
+++ b/Systems/ExperienceSystem.cs
@@ -79,20 +79,28 @@ namespace RPGMods.Systems
             else EXPGained = UnitLevel.Level;
 
             int level_diff = UnitLevel.Level - player_level;
-            //if (level_diff > 10) level_diff = 10;
-
-            if (level_diff > 0) EXPGained = (int)(EXPGained * (1 + level_diff * 0.1) * EXPMultiplier);
-            else{
-                float xpMult = level_diff * -1.0f;
-                xpMult = xpMult / (xpMult + 10.0f);
-                EXPGained = (int)(EXPGained * xpMult);
+            
+            switch(level_diff)
+            {
+                case > 0:
+                    EXPGained = (int)(EXPGained * (1 + level_diff * 0.1) * EXPMultiplier);
+                    break;
+                case 0:
+                    EXPGained = UnitLevel.Level;
+                    break;
+                case < 0 when level_diff >= -5:
+                    EXPGained = (int)(EXPGained * 0.75 * EXPMultiplier);
+                    break;
+                case < 0 when level_diff >= -10:
+                    EXPGained = (int)(EXPGained * 0.50 * EXPMultiplier);
+                    break;
+                case < 0 when level_diff >= -15:
+                    EXPGained = (int)(EXPGained * 0.25 * EXPMultiplier);
+                    break;
+                case <= -20:
+                    EXPGained = (int)(EXPGained * 0.10 * EXPMultiplier);
+                    break;
             }
-            /*
-            else if (level_diff <= -20) EXPGained = (int) Math.Ceiling(EXPGained * 0.10 * EXPMultiplier);
-            else if (level_diff <= -15) EXPGained = (int) Math.Ceiling(EXPGained * 0.25 * EXPMultiplier);
-            else if (level_diff <= -10) EXPGained = (int) Math.Ceiling(EXPGained * 0.50 * EXPMultiplier);
-            else if (level_diff <= -5) EXPGained = (int) Math.Ceiling(EXPGained * 0.75 * EXPMultiplier);
-            else EXPGained = (int)(EXPGained * EXPMultiplier);*/
 
             if (PlayerGroup.AllyCount > 0)
             {


### PR DESCRIPTION
Fix 0 XP issue where same level NPC vs Player can cause 0 EXP to be calculated. Additionally adding a sub % of lower tier levels to still provide some set of experience but not dramatic depending on the level difference.