### PR TITLE
🐛 Fix error in serverlaunchfix/client.

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -440,6 +440,12 @@ namespace RPGMods
 
         public override void Load()
         {
+            if(!IsServer)
+            {
+                Log.LogWarning("RPGMods is a server plugin. Not continuing to load on client.");
+                return;
+            }
+            
             InitConfig();
             Logger = Log;
             harmony = new Harmony("RPGMods");


### PR DESCRIPTION
There is a check inside of the Server world that is throwing when loading later on client. The plugin should just refuse to continue to load on the server instead. I've made this a warning and it should display once when on client and stop loading.