### PR TITLE
Update experience to ensure consistency

### DIFF
--- a/Hooks/DeathHook.cs
+++ b/Hooks/DeathHook.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System;
+using HarmonyLib;
 using ProjectM;
 using ProjectM.Network;
 using RPGMods.Commands;
@@ -11,6 +12,7 @@ namespace RPGMods.Hooks {
 [HarmonyPatch]
 public class DeathEventListenerSystem_Patch
 {
+    public static bool deathLogging = false;
     [HarmonyPatch(typeof(DeathEventListenerSystem), "OnUpdate")]
     [HarmonyPostfix]
     public static void Postfix(DeathEventListenerSystem __instance)
@@ -24,13 +26,24 @@ public class DeathEventListenerSystem_Patch
                 if (WorldDynamicsSystem.isFactionDynamic) WorldDynamicsSystem.MobKillMonitor(ev.Died);
 
                 //-- Player Creature Kill Tracking
-                if (__instance.EntityManager.HasComponent<PlayerCharacter>(ev.Killer) && __instance.EntityManager.HasComponent<Movement>(ev.Died))
+                var killer = ev.Killer;
+                
+                // If the entity killing is a minion, switch the killer to the owner of the minion.
+                if (__instance.EntityManager.HasComponent<Minion>(killer)) {
+                    if (deathLogging) Plugin.Logger.LogInfo($"{DateTime.Now}: Minion killed entity. Getting owner...");
+                    if (__instance.EntityManager.TryGetComponentData<EntityOwner>(killer, out var entityOwner)) {
+                        killer = entityOwner.Owner;
+                        if (deathLogging) Plugin.Logger.LogInfo($"{DateTime.Now}: Owner found, switching killer to owner.");
+                    }
+                }
+                
+                if (__instance.EntityManager.HasComponent<PlayerCharacter>(killer) && __instance.EntityManager.HasComponent<Movement>(ev.Died))
                 {
-                    if (ExperienceSystem.isEXPActive) ExperienceSystem.EXPMonitor(ev.Killer, ev.Died);
-                    if (HunterHuntedSystem.isActive) HunterHuntedSystem.PlayerUpdateHeat(ev.Killer, ev.Died);
-                    if (WeaponMasterSystem.isMasteryEnabled) WeaponMasterSystem.UpdateMastery(ev.Killer, ev.Died);
-                    if (Bloodlines.areBloodlinesEnabled) Bloodlines.UpdateBloodline(ev.Killer, ev.Died);
-                    if (PvPSystem.isHonorSystemEnabled) PvPSystem.MobKillMonitor(ev.Killer, ev.Died);
+                    if (ExperienceSystem.isEXPActive) ExperienceSystem.EXPMonitor(killer, ev.Died);
+                    if (HunterHuntedSystem.isActive) HunterHuntedSystem.PlayerUpdateHeat(killer, ev.Died);
+                    if (WeaponMasterSystem.isMasteryEnabled) WeaponMasterSystem.UpdateMastery(killer, ev.Died);
+                    if (Bloodlines.areBloodlinesEnabled) Bloodlines.UpdateBloodline(killer, ev.Died);
+                    if (PvPSystem.isHonorSystemEnabled) PvPSystem.MobKillMonitor(killer, ev.Died);
 
                 }
                 //-- ----------------------

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -1,4 +1,5 @@
-﻿using BepInEx;
+﻿using System;
+using BepInEx;
 using BepInEx.Configuration;
 using BepInEx.Unity.IL2CPP;
 using BepInEx.Logging;
@@ -94,6 +95,7 @@ namespace RPGMods
         private static ConfigEntry<float> EXPFormula_1;
         private static ConfigEntry<double> EXPGroupModifier;
         private static ConfigEntry<float> EXPGroupMaxDistance;
+        private static ConfigEntry<int> EXPGroupLevelScheme;
 
         private static ConfigEntry<bool> EnableWeaponMaster;
         private static ConfigEntry<bool> EnableWeaponMasterDecay;
@@ -299,7 +301,7 @@ namespace RPGMods
             EXPGroupModifier = Config.Bind("Experience", "Group Modifier", 0.75, "Set the modifier for EXP gained for each ally(player) in vicinity.\n" +
                 "Example if you have 2 ally nearby, EXPGained = ((EXPGained * Modifier)*Modifier)");
             EXPGroupMaxDistance = Config.Bind("Experience", "Ally Max Distance", 50f, "Set the maximum distance an ally(player) has to be from the player for them to share EXP with the player");
-            
+            EXPGroupLevelScheme = Config.Bind("Experience", "Group level Scheme", 3, "Configure the group levelling scheme. See documentation.");
 
             EnableWeaponMaster = Config.Bind("Mastery", "Enable Weapon Mastery", true, "Enable/disable the weapon mastery system.");
             EnableWeaponMasterDecay = Config.Bind("Mastery", "Enable Mastery Decay", true, "Enable/disable the decay of weapon mastery when the user is offline.");
@@ -560,6 +562,10 @@ namespace RPGMods
             ExperienceSystem.GroupModifier = EXPGroupModifier.Value;
             ExperienceSystem.GroupMaxDistance = EXPGroupMaxDistance.Value;
             ExperienceSystem.easyLvl15 = EasyLevel15.Value;
+
+            if (Enum.IsDefined(typeof(ExperienceSystem.GroupLevelScheme), EXPGroupLevelScheme.Value)) {
+                ExperienceSystem.groupLevelScheme = (ExperienceSystem.GroupLevelScheme)EXPGroupLevelScheme.Value;
+            }
 
             Logger.LogInfo("Loading weapon mastery config");
             WeaponMasterSystem.isMasteryEnabled = EnableWeaponMaster.Value;

--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ Set the modifier for EXP gained for each ally(player) in vicinity.\
 Example if you have 2 ally nearby, EXPGained = ((EXPGained * Modifier)*Modifier)
 - `Ally Max Distance` [default `50`]\
 Set the maximum distance an ally(player) has to be from the player for them to share EXP with the player
-- `Group Level Scheme` [default `2`]\
+- `Group Level Scheme` [default `3`]\
 Set the group levelling scheme for allied players. See experience section for scheme options.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -13,6 +13,34 @@ complete with exp sharing between clan members or other players designated as al
 </details>
 Now with a class system, currently undocumented.
 
+#### Group XP
+Killing with other vampires can provide group XP. This is governed by `Group Modifier`, `Group Level Scheme` and `Ally Max Distance`.
+<details>
+<summary>Group XP options</summary>
+
+A vampire is considered to be in your group if they are in the same clan and within the distance specified by `Ally Max Distance`.
+
+Group XP is modified by the `Group Modifier` and `Group Level Scheme`.
+
+Given a scenario of 2 allied vampires close together, PC 1 (lvl 10), PC 2 (lvl 20), where PC 1 kills the mob, the following table shows the level used to calculate each players XP:
+
+| Scheme | Name        | PC 1 | PC 2 |
+|--------|-------------|------|------|
+| 0      | None        | 10   | N/A  |
+| 1      | Average     | 15   | 15   |
+| 2      | Max         | 20   | 20   |
+| 3      | Each player | 10   | 20   |
+| 4      | Killer      | 10   | 10   |
+
+Notes:
+- `0`: Effectively disables group XP. Each vampire only gets XP for mobs that they get the killing blow on
+- `1`: Higher level vampires get more XP when grouped with lower level vampires
+- `2`: Lower level players are penalised when playing with higher level players
+- `3`: Each player gets XP based on their own level (Default behaviour)
+- `4`: Each player gets XP based on who killed the mob (Previous version behaviour)
+
+</details>
+
 ## Mastery System
 <details>
 <summary>Mastery System</summary>
@@ -439,6 +467,8 @@ Set the modifier for EXP gained for each ally(player) in vicinity.\
 Example if you have 2 ally nearby, EXPGained = ((EXPGained * Modifier)*Modifier)
 - `Ally Max Distance` [default `50`]\
 Set the maximum distance an ally(player) has to be from the player for them to share EXP with the player
+- `Group Level Scheme` [default `2`]\
+Set the group levelling scheme for allied players. See experience section for scheme options.
 
 </details>
 

--- a/Systems/ExperienceSystem.cs
+++ b/Systems/ExperienceSystem.cs
@@ -15,7 +15,6 @@ using UnityEngine;
 using Cache = RPGMods.Utils.Cache;
 using Unity.Entities.UniversalDelegates;
 using MS.Internal.Xml.XPath;
-using Steamworks;
 
 namespace RPGMods.Systems
 {
@@ -41,145 +40,122 @@ namespace RPGMods.Systems
         public static bool xpLogging = false;
         public static void EXPMonitor(Entity killerEntity, Entity victimEntity)
         {
-            //-- Check victim is not a summon
             if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Kill Found, Handling XP");
-            if (entityManager.HasComponent<Minion>(victimEntity)) return;
-
-            if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Not a Minion, checking level");
+            
+            //-- Check victim is not a summon
+            if (entityManager.HasComponent<Minion>(victimEntity)) {
+                if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Minion killed, exiting XP");
+                return;
+            }
+            
             //-- Check victim has a level
-            if (!entityManager.HasComponent<UnitLevel>(victimEntity)) return;
-
-            if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Has Level, fetching allies");
+            if (!entityManager.HasComponent<UnitLevel>(victimEntity)) {
+                if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Has no level, exiting XP");
+                return;
+            }
+            
             //-- Must be executed from main thread
-            Helper.GetAllies(killerEntity, out var PlayerGroup);
+            if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Fetching allies...");
+            Helper.GetAllies(killerEntity, out var playerGroup);
             //-- ---------------------------------
-            if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Allies Fetched, player group is " + PlayerGroup + ", Total ally count of " + PlayerGroup.AllyCount);
-            UpdateEXP(killerEntity, victimEntity, PlayerGroup);
+            if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Allies Fetched, Total ally count of " + playerGroup.AllyCount);
+            UpdateEXP(killerEntity, victimEntity, playerGroup);
         }
 
-        public static void UpdateEXP(Entity killerEntity, Entity victimEntity, PlayerGroup PlayerGroup) {
-            if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Began XP Update, player group is size " + PlayerGroup.AllyCount);
-            PlayerCharacter player = entityManager.GetComponentData<PlayerCharacter>(killerEntity);
-            Entity userEntity = player.UserEntity;
-            User user = entityManager.GetComponentData<User>(userEntity);
-            ulong SteamID = user.PlatformId;
-            if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": SteamID of killer is " + SteamID);
-
-            int player_level = 0;
-            if (Database.player_experience.TryGetValue(SteamID, out int exp))
-            {
-                player_level = convertXpToLevel(exp);
-                if (exp >= convertLevelToXp(MaxLevel)) return;
+        public static void UpdateEXP(Entity killerEntity, Entity victimEntity, PlayerGroup playerGroup) {
+            if (xpLogging) {
+                Plugin.Logger.LogInfo($"{DateTime.Now}: Killer entity: {killerEntity}");
+                Plugin.Logger.LogInfo($"{DateTime.Now}: Began XP Update, current ally count: {playerGroup.AllyCount}");
             }
 
-            UnitLevel UnitLevel = entityManager.GetComponentData<UnitLevel>(victimEntity);
+            var unitLevel = entityManager.GetComponentData<UnitLevel>(victimEntity);
 
             bool isVBlood;
             if (entityManager.HasComponent<BloodConsumeSource>(victimEntity))
             {
-                BloodConsumeSource BloodSource = entityManager.GetComponentData<BloodConsumeSource>(victimEntity);
-                isVBlood = BloodSource.UnitBloodType.Equals(vBloodType);
+                BloodConsumeSource bloodSource = entityManager.GetComponentData<BloodConsumeSource>(victimEntity);
+                isVBlood = bloodSource.UnitBloodType.Equals(vBloodType);
             }
             else
             {
                 isVBlood = false;
             }
 
-            int EXPGained;
-            if (isVBlood) EXPGained = (int)(UnitLevel.Level * VBloodMultiplier);
-            else EXPGained = UnitLevel.Level;
-
-            int level_diff = UnitLevel.Level - player_level;
-            //if (level_diff > 10) level_diff = 10;
-
-            if (level_diff >= 0) EXPGained = (int)(EXPGained * (1 + level_diff * 0.1) * EXPMultiplier);
-            else{
-                float xpMult = level_diff * -1.0f;
-                xpMult = xpMult / (xpMult + 10.0f);
-                EXPGained = (int)(EXPGained * (1-xpMult));
-            }
-            /*
-            else if (level_diff <= -20) EXPGained = (int) Math.Ceiling(EXPGained * 0.10 * EXPMultiplier);
-            else if (level_diff <= -15) EXPGained = (int) Math.Ceiling(EXPGained * 0.25 * EXPMultiplier);
-            else if (level_diff <= -10) EXPGained = (int) Math.Ceiling(EXPGained * 0.50 * EXPMultiplier);
-            else if (level_diff <= -5) EXPGained = (int) Math.Ceiling(EXPGained * 0.75 * EXPMultiplier);
-            else EXPGained = (int)(EXPGained * EXPMultiplier);*/
-
-            if (PlayerGroup.AllyCount > 0) {
-                if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Beginning XP Sharing");
-                List<Entity> CloseAllies = new();
-                if (Cache.PlayerLocations.TryGetValue(killerEntity, out var playerPos)) {
-                    if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Got Player Position from Cache");
-                    foreach (var ally in PlayerGroup.Allies) {
-                        if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Iterating over allies, ally is " + ally.GetHashCode());
-                        if (Cache.PlayerLocations.TryGetValue(ally.Value, out var allyPos)) {
-                            if (xpLogging) Plugin.Logger.LogInfo(   DateTime.Now + ": Got Ally Position");
-                            var Distance = math.distance(playerPos.Position.xz, allyPos.Position.xz);
-                            if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Distance is " + Distance + ", Max Distance is " + GroupMaxDistance);
-                            if (Distance <= GroupMaxDistance) {
-                                if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Adjusting XP Gain and adding ally to the close allies list");
-                                EXPGained = (int)(EXPGained * GroupModifier);
-                                CloseAllies.Add(ally.Key);
-                            }
-                        } else {
-                            if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Could not get position, update the cache!");
-                        }
+            var killerLocation = entityManager.GetComponentData<LocalToWorld>(killerEntity);
+            
+            List<Entity> closeAllies = new();
+            foreach (var ally in playerGroup.Allies) {
+                if (xpLogging) Plugin.Logger.LogInfo($"{DateTime.Now}: Getting close allies");
+                if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Iterating over allies, ally is " + ally.GetHashCode());
+                if (Cache.PlayerLocations.TryGetValue(ally.Value, out var allyPos)) {
+                    if (xpLogging) Plugin.Logger.LogInfo(   DateTime.Now + ": Got Ally Position");
+                    var distance = math.distance(killerLocation.Position.xz, allyPos.Position.xz);
+                    if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Distance is " + distance + ", Max Distance is " + GroupMaxDistance);
+                    if (distance <= GroupMaxDistance) {
+                        if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Adjusting XP Gain and adding ally to the close allies list");
+                        closeAllies.Add(ally.Key);
                     }
-                }
-
-                if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Running Share EXP");
-                foreach (var teammate in CloseAllies) {
-                    if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Sharing EXP to " + teammate.GetHashCode());
-                    ShareEXP(teammate, EXPGained);
+                } else {
+                    if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Could not get position, update the cache!");
                 }
             }
 
-            int currentXP = exp <= 0 ? EXPGained : exp + EXPGained;
-            Database.player_experience[SteamID] = currentXP;
-
-            SetLevel(killerEntity, userEntity, SteamID);
-            if (Database.player_log_exp.TryGetValue(SteamID, out bool isLogging))
-            {
-                if (isLogging) {
-                    GetLevelAndProgress(currentXP, out int progress, out int earned, out int needed);
-                    Output.SendLore(userEntity, $"<color=#ffdd00>You gain {EXPGained} XP by slaying a Lv.{UnitLevel.Level} enemy.</color> [ XP: <color=#fffffffe> {earned}</color>/<color=#fffffffe>{needed}</color> ]");
-                }
+            if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Running Assign EXP for all close allied players");
+            var isGroup = closeAllies.Count > 1;
+            foreach (var teammate in closeAllies) {
+                if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Assigning EXP to " + teammate.GetHashCode());
+                AssignExp(teammate, unitLevel.Level, isVBlood, isGroup);
             }
         }
 
-        public static void ShareEXP(Entity user, int EXPGain) {
-            if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Getting User Component from Ally");
-            //var user_component = entityManager.GetComponentData<User>(user);
-            if (EXPGain > 0) {
-                bool gotUser = entityManager.TryGetComponentData<User>(user, out User user_component);
-                ulong SteamID;
-                if (!gotUser) {
-                    bool gotPC = entityManager.TryGetComponentData<PlayerCharacter>(user, out PlayerCharacter pc);
-                    if (!gotPC) {
-                        Plugin.Logger.LogInfo(DateTime.Now + ": Player Character Component unavailable, available components are: " + Plugin.Server.EntityManager.Debug.GetEntityInfo(user));
-                    } else {
-                        Entity userEntity = pc.UserEntity;
-                        bool gotUserComponent = entityManager.TryGetComponentData<User>(userEntity, out user_component);
-                        if (!gotUserComponent) {
-                            Plugin.Logger.LogInfo(DateTime.Now + ": User Component unavailable, available components from pc.UserEntity are: " + Plugin.Server.EntityManager.Debug.GetEntityInfo(userEntity));
-                        }
-                        SteamID = user_component.PlatformId;
-                        if (Database.player_log_exp.TryGetValue(SteamID, out bool isLogging)) {
-                            if (isLogging) {
-                                Output.SendLore(userEntity, $"<color=#ffdd00>You gain {EXPGain} experience points by participating in the killing of an enemy.</color>");
-                            }
-                        }
-                    }
-                    
-                }
-                SteamID = user_component.PlatformId;
-                if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Trying to get allies exp");
-                Database.player_experience.TryGetValue(SteamID, out var exp);
-                if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Trying to set allies exp");
-                Database.player_experience[SteamID] = exp + EXPGain;
-                if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Running Set Level for Ally");
-                SetLevel(user_component.LocalCharacter._Entity, user, SteamID);
+        public static void AssignExp(Entity entity, int mobLevel, bool isVBlood, bool isGroup) {
+            if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Getting User Component from entity");
+
+            if (!entityManager.TryGetComponentData(entity, out PlayerCharacter pc)) {
+                if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Player Character Component unavailable, available components are: " + Plugin.Server.EntityManager.Debug.GetEntityInfo(entity));
+                return;
+            } 
+            var user = pc.UserEntity;
+            if (!entityManager.TryGetComponentData(user, out User userComponent)) {
+                if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": User Component unavailable, available components from pc.UserEntity are: " + Plugin.Server.EntityManager.Debug.GetEntityInfo(user));
+                // Can't really do anything at this point
+                return;
             }
+
+            var steamID = userComponent.PlatformId;
+            int playerLevel = 0;
+            if (Database.player_experience.TryGetValue(steamID, out int currentXp))
+            {
+                playerLevel = convertXpToLevel(currentXp);
+                if (currentXp >= convertLevelToXp(MaxLevel)) return;
+            }
+
+            var xpGained = isVBlood ? (int)(mobLevel * VBloodMultiplier) : mobLevel;
+
+            var levelDiff = mobLevel - playerLevel;
+            
+            if (levelDiff >= 0) xpGained = (int)(xpGained * (1 + levelDiff * 0.1) * EXPMultiplier);
+            else{
+                float xpMult = levelDiff * -1.0f;
+                xpMult = xpMult / (xpMult + 10.0f);
+                xpGained = (int)(xpGained * (1-xpMult));
+            }
+
+            if (isGroup) {
+                xpGained = (int)(xpGained * GroupModifier);
+            }
+            
+            Database.player_experience[steamID] = Math.Max(currentXp, 0) + xpGained;;
+
+            if (Database.player_log_exp.TryGetValue(steamID, out bool isLogging))
+            {
+                if (isLogging) {
+                    GetLevelAndProgress(currentXp, out int progress, out int earned, out int needed);
+                    Output.SendLore(user, $"<color=#ffdd00>You gain {xpGained} XP by slaying a Lv.{mobLevel} enemy.</color> [ XP: <color=#fffffffe> {earned}</color>/<color=#fffffffe>{needed}</color> ]");
+                }
+            }
+            
+            SetLevel(userComponent.LocalCharacter._Entity, user, steamID);
         }
 
         public static void LoseEXP(Entity playerEntity)
@@ -222,8 +198,8 @@ namespace RPGMods.Systems
 
         public static void SetLevel(Entity entity, Entity user, ulong SteamID)
         {
-            if (!Database.player_experience.ContainsKey(SteamID)) Database.player_experience[SteamID] = 0;
-            if (!Database.player_abilityIncrease.ContainsKey(SteamID)) Database.player_abilityIncrease[SteamID] = 0;
+            Database.player_experience.TryAdd(SteamID, 0);
+            Database.player_abilityIncrease.TryAdd(SteamID, 0);
 
             float level = convertXpToLevel(Database.player_experience[SteamID]);
             if (level < 0) return;
@@ -232,9 +208,9 @@ namespace RPGMods.Systems
                 Database.player_experience[SteamID] = convertLevelToXp(MaxLevel);
             }
 
-            bool levelDataExists = Cache.player_level.TryGetValue(SteamID, out var level_);
+            bool levelDataExists = Cache.player_level.TryGetValue(SteamID, out var storedLevel);
             if (levelDataExists){
-                if (level_ < level) 
+                if (storedLevel < level) 
                 {
                     Cache.player_level[SteamID] = level;
                     Helper.ApplyBuff(user, entity, Database.Buff.LevelUp_Buff);
@@ -242,7 +218,7 @@ namespace RPGMods.Systems
                     if (LevelRewardsOn)
                     {
                         //increases by level
-                        for (var i = level_+1; i <= level; i++)
+                        for (var i = storedLevel+1; i <= level; i++)
                         {
                             //default rewards for leveling up
                             Database.player_abilityIncrease[SteamID] += 1;

--- a/Systems/ExperienceSystem.cs
+++ b/Systems/ExperienceSystem.cs
@@ -11,6 +11,7 @@ using Unity.Mathematics;
 using RPGMods.Utils;
 using System.Threading.Tasks;
 using System.Collections.Concurrent;
+using System.Linq;
 using UnityEngine;
 using Cache = RPGMods.Utils.Cache;
 using Unity.Entities.UniversalDelegates;
@@ -35,9 +36,60 @@ namespace RPGMods.Systems
         public static bool easyLvl15 = true;
 
         public static double EXPLostOnDeath = 0.10;
+        
+        public enum GroupLevelScheme {
+            None = 0,
+            Average = 1,
+            Max = 2,
+            EachPlayer = 3,
+            Killer = 4,
+        }
+
+        public static GroupLevelScheme groupLevelScheme = GroupLevelScheme.Average;
 
         private static readonly PrefabGUID vBloodType = new PrefabGUID(1557174542);
         public static bool xpLogging = false;
+        
+        private struct CloseAlly {
+            public Entity userEntity;
+            public User userComponent;
+            public int currentXp;
+            public int playerLevel;
+            public ulong steamID;
+            public bool isKiller;
+        }
+        
+        private static bool ConvertToAlly(Entity entity, out CloseAlly ally) {
+            if (!entityManager.TryGetComponentData(entity, out PlayerCharacter pc)) {
+                if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Player Character Component unavailable, available components are: " + Plugin.Server.EntityManager.Debug.GetEntityInfo(entity));
+                ally = new CloseAlly();
+                return false;
+            } 
+            var user = pc.UserEntity;
+            if (!entityManager.TryGetComponentData(user, out User userComponent)) {
+                if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": User Component unavailable, available components from pc.UserEntity are: " + Plugin.Server.EntityManager.Debug.GetEntityInfo(user));
+                // Can't really do anything at this point
+                ally = new CloseAlly();
+                return false;
+            }
+                        
+            var steamID = userComponent.PlatformId;
+            var playerLevel = 0;
+            if (Database.player_experience.TryGetValue(steamID, out int currentXp))
+            {
+                playerLevel = convertXpToLevel(currentXp);
+            }
+                        
+            ally = new CloseAlly() {
+                currentXp = currentXp,
+                playerLevel = playerLevel,
+                steamID = steamID,
+                userEntity = user,
+                userComponent = userComponent
+            };
+            return true;
+        }
+
         public static void EXPMonitor(Entity killerEntity, Entity victimEntity)
         {
             if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Kill Found, Handling XP");
@@ -53,83 +105,130 @@ namespace RPGMods.Systems
                 if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Has no level, exiting XP");
                 return;
             }
+
+            if (xpLogging) Plugin.Logger.LogInfo($"{DateTime.Now}: Killer entity: {killerEntity}");
             
             //-- Must be executed from main thread
             if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Fetching allies...");
-            Helper.GetAllies(killerEntity, out var playerGroup);
-            //-- ---------------------------------
-            if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Allies Fetched, Total ally count of " + playerGroup.AllyCount);
-            UpdateEXP(killerEntity, victimEntity, playerGroup);
-        }
-
-        public static void UpdateEXP(Entity killerEntity, Entity victimEntity, PlayerGroup playerGroup) {
-            if (xpLogging) {
-                Plugin.Logger.LogInfo($"{DateTime.Now}: Killer entity: {killerEntity}");
-                Plugin.Logger.LogInfo($"{DateTime.Now}: Began XP Update, current ally count: {playerGroup.AllyCount}");
+            List<CloseAlly> closeAllies = new();
+            if (groupLevelScheme == GroupLevelScheme.None || GroupModifier == 0) {
+                // If we are using a scheme of None or the Group Modifier is 0, we are our only ally
+                if (ConvertToAlly(killerEntity, out var ally)) {
+                    ally.isKiller = true;
+                    closeAllies.Add(ally);
+                }
             }
+            else {
+                Helper.GetAllies(killerEntity, out var playerGroup);
+                
+                if (xpLogging) Plugin.Logger.LogInfo($"{DateTime.Now}: Getting close allies");
+                
+                var killerLocation = entityManager.GetComponentData<LocalToWorld>(killerEntity);
+                foreach (var ally in playerGroup.Allies) {
+                    if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Iterating over allies, ally is " + ally.GetHashCode());
+                    if (!Cache.PlayerLocations.TryGetValue(ally.Value, out var allyPos)) {
+                        if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Could not get position, update the cache!");
+                        continue;
+                    }
+                    if (xpLogging) Plugin.Logger.LogInfo(   DateTime.Now + ": Got Ally Position");
+                    var distance = math.distance(killerLocation.Position.xz, allyPos.Position.xz);
+                    if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Distance is " + distance + ", Max Distance is " + GroupMaxDistance);
+                    if (!(distance <= GroupMaxDistance)) continue;
+                    if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Converting entity to ally...");
 
+                    if (ConvertToAlly(ally.Key, out var closeAlly)) {
+                        closeAlly.isKiller = killerEntity.Equals(ally.Key);
+                        closeAllies.Add(closeAlly);
+                    }
+                }
+            }
+            
+            //-- ---------------------------------
+            if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Allies Fetched, Total ally count of " + closeAllies.Count);
+            
             var unitLevel = entityManager.GetComponentData<UnitLevel>(victimEntity);
 
             bool isVBlood;
             if (entityManager.HasComponent<BloodConsumeSource>(victimEntity))
             {
-                BloodConsumeSource bloodSource = entityManager.GetComponentData<BloodConsumeSource>(victimEntity);
+                var bloodSource = entityManager.GetComponentData<BloodConsumeSource>(victimEntity);
                 isVBlood = bloodSource.UnitBloodType.Equals(vBloodType);
             }
             else
             {
                 isVBlood = false;
             }
+            UpdateEXP(unitLevel.Level, isVBlood, closeAllies);
+        }
 
-            var killerLocation = entityManager.GetComponentData<LocalToWorld>(killerEntity);
-            
-            List<Entity> closeAllies = new();
-            foreach (var ally in playerGroup.Allies) {
-                if (xpLogging) Plugin.Logger.LogInfo($"{DateTime.Now}: Getting close allies");
-                if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Iterating over allies, ally is " + ally.GetHashCode());
-                if (Cache.PlayerLocations.TryGetValue(ally.Value, out var allyPos)) {
-                    if (xpLogging) Plugin.Logger.LogInfo(   DateTime.Now + ": Got Ally Position");
-                    var distance = math.distance(killerLocation.Position.xz, allyPos.Position.xz);
-                    if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Distance is " + distance + ", Max Distance is " + GroupMaxDistance);
-                    if (distance <= GroupMaxDistance) {
-                        if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Adjusting XP Gain and adding ally to the close allies list");
-                        closeAllies.Add(ally.Key);
-                    }
-                } else {
-                    if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Could not get position, update the cache!");
-                }
+        private static void UpdateEXP(int mobLevel, bool isVBlood, List<CloseAlly> closeAllies) {
+            // Calculate the modified player level
+            var modifiedPlayerLevel = 0;
+            switch (groupLevelScheme) {
+                case GroupLevelScheme.Average:
+                    modifiedPlayerLevel += (int)closeAllies.Average(x => x.playerLevel);
+                    break;
+                case GroupLevelScheme.Max:
+                    modifiedPlayerLevel = closeAllies.Max(x => x.playerLevel);
+                    break;
+                case GroupLevelScheme.Killer:
+                    // If the killer is not found, use MaxLevel
+                    modifiedPlayerLevel = closeAllies.Where(x => x.isKiller).Select(x => x.playerLevel).FirstOrDefault(MaxLevel);
+                    break;
+                case GroupLevelScheme.EachPlayer:
+                case GroupLevelScheme.None:
+                    // Do nothing to modify the player level
+                    break;
+                default:
+                    Plugin.Logger.LogWarning($"{DateTime.Now}: Group level scheme unknown");
+                    break;
             }
 
             if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Running Assign EXP for all close allied players");
-            var isGroup = closeAllies.Count > 1;
+            var isGroup = closeAllies.Count > 1 && groupLevelScheme != GroupLevelScheme.None;
             foreach (var teammate in closeAllies) {
                 if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Assigning EXP to " + teammate.GetHashCode());
-                AssignExp(teammate, unitLevel.Level, isVBlood, isGroup);
+                switch (groupLevelScheme) {
+                    case GroupLevelScheme.Average:
+                    case GroupLevelScheme.Max:
+                    case GroupLevelScheme.Killer:
+                        // modifiedPlayerLevel already up to date
+                        break;
+                    case GroupLevelScheme.EachPlayer:
+                        modifiedPlayerLevel = teammate.playerLevel;
+                        break;
+                    case GroupLevelScheme.None:
+                        modifiedPlayerLevel = teammate.playerLevel;
+                        break;
+                }
+                if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + $": IsKiller: {teammate.isKiller} LVL: {teammate.playerLevel} M_LVL: {modifiedPlayerLevel} {groupLevelScheme}");
+                AssignExp(teammate, mobLevel, modifiedPlayerLevel, isVBlood, isGroup);
             }
         }
 
-        public static void AssignExp(Entity entity, int mobLevel, bool isVBlood, bool isGroup) {
-            if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Getting User Component from entity");
+        private static void AssignExp(CloseAlly ally, int mobLevel, int modifiedPlayerLevel, bool isVBlood, bool isGroup) {
+            if (ally.currentXp >= convertLevelToXp(MaxLevel)) return;
 
-            if (!entityManager.TryGetComponentData(entity, out PlayerCharacter pc)) {
-                if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": Player Character Component unavailable, available components are: " + Plugin.Server.EntityManager.Debug.GetEntityInfo(entity));
-                return;
-            } 
-            var user = pc.UserEntity;
-            if (!entityManager.TryGetComponentData(user, out User userComponent)) {
-                if (xpLogging) Plugin.Logger.LogInfo(DateTime.Now + ": User Component unavailable, available components from pc.UserEntity are: " + Plugin.Server.EntityManager.Debug.GetEntityInfo(user));
-                // Can't really do anything at this point
-                return;
+            var xpGained = CalculateXp(modifiedPlayerLevel, mobLevel, isVBlood);
+
+            if (isGroup) {
+                xpGained = (int)(xpGained * GroupModifier);
             }
+            
+            Database.player_experience[ally.steamID] = Math.Max(ally.currentXp, 0) + xpGained;;
 
-            var steamID = userComponent.PlatformId;
-            int playerLevel = 0;
-            if (Database.player_experience.TryGetValue(steamID, out int currentXp))
+            if (Database.player_log_exp.TryGetValue(ally.steamID, out bool isLogging))
             {
-                playerLevel = convertXpToLevel(currentXp);
-                if (currentXp >= convertLevelToXp(MaxLevel)) return;
+                if (isLogging) {
+                    GetLevelAndProgress(ally.currentXp, out int progress, out int earned, out int needed);
+                    Output.SendLore(ally.userEntity, $"<color=#ffdd00>You gain {xpGained} XP by slaying a Lv.{mobLevel} enemy.</color> [ XP: <color=#fffffffe> {earned}</color>/<color=#fffffffe>{needed}</color> ]");
+                }
             }
+            
+            SetLevel(ally.userComponent.LocalCharacter._Entity, ally.userEntity, ally.steamID);
+        }
 
+        private static int CalculateXp(int playerLevel, int mobLevel, bool isVBlood) {
             var xpGained = isVBlood ? (int)(mobLevel * VBloodMultiplier) : mobLevel;
 
             var levelDiff = mobLevel - playerLevel;
@@ -137,25 +236,11 @@ namespace RPGMods.Systems
             if (levelDiff >= 0) xpGained = (int)(xpGained * (1 + levelDiff * 0.1) * EXPMultiplier);
             else{
                 float xpMult = levelDiff * -1.0f;
-                xpMult = xpMult / (xpMult + 10.0f);
+                xpMult /= (xpMult + 10.0f);
                 xpGained = (int)(xpGained * (1-xpMult));
             }
 
-            if (isGroup) {
-                xpGained = (int)(xpGained * GroupModifier);
-            }
-            
-            Database.player_experience[steamID] = Math.Max(currentXp, 0) + xpGained;;
-
-            if (Database.player_log_exp.TryGetValue(steamID, out bool isLogging))
-            {
-                if (isLogging) {
-                    GetLevelAndProgress(currentXp, out int progress, out int earned, out int needed);
-                    Output.SendLore(user, $"<color=#ffdd00>You gain {xpGained} XP by slaying a Lv.{mobLevel} enemy.</color> [ XP: <color=#fffffffe> {earned}</color>/<color=#fffffffe>{needed}</color> ]");
-                }
-            }
-            
-            SetLevel(userComponent.LocalCharacter._Entity, user, steamID);
+            return xpGained;
         }
 
         public static void LoseEXP(Entity playerEntity)


### PR DESCRIPTION
Group and solo experience now both apply XP based on comparing mob level to unit level. This ensures that each player will receive the same XP regardless off who gets the killing blow.

For example:
Consider a lvl 10 NPC, with 2 PC, lvl 1 and lvl 20

Previously:
- if the lvl 1 PC lands a killing blow, both units calculate XP based on a level difference of 9
- if the lvl 20 PC lands a killing blow, both units calculate XP based on a level difference of -10

Now the following always happens:
- lvl 1 PC gets XP based on lvl difference of 9
- lvl 20 PC gets XP based on lvl difference of -10

Kills made by a PC minion will now count as the PC instead of being ignored. This helps ensure that using spells that spawn minions don't negatively impact the levelling experience (pun intended).

Also updates logging to ensure each player has the same style of XP log reported to them. Each player now receives the same style of message showing the mob level and experience gain.