### PR TITLE
Fix displaying current XP progress on gain

### DIFF
--- a/Systems/ExperienceSystem.cs
+++ b/Systems/ExperienceSystem.cs
@@ -223,13 +223,14 @@ namespace RPGMods.Systems
             if (isGroup) {
                 xpGained = (int)(xpGained * GroupModifier);
             }
-            
-            Database.player_experience[ally.steamID] = Math.Max(ally.currentXp, 0) + xpGained;;
+
+            var newXp = Math.Max(ally.currentXp, 0) + xpGained;
+            Database.player_experience[ally.steamID] = newXp;
 
             if (Database.player_log_exp.TryGetValue(ally.steamID, out bool isLogging))
             {
                 if (isLogging) {
-                    GetLevelAndProgress(ally.currentXp, out int progress, out int earned, out int needed);
+                    GetLevelAndProgress(newXp, out int progress, out int earned, out int needed);
                     Output.SendLore(ally.userEntity, $"<color=#ffdd00>You gain {xpGained} XP by slaying a Lv.{mobLevel} enemy.</color> [ XP: <color=#fffffffe> {earned}</color>/<color=#fffffffe>{needed}</color> ]");
                 }
             }


### PR DESCRIPTION
Current the XP progress displayed is the old XP instead of what the XP is after the gain from the kill. This fixes that issue.