### PR TITLE
Fix spawning gloomrot spiderbot tanks

### DIFF
--- a/Hooks/BuffHook.cs
+++ b/Hooks/BuffHook.cs
@@ -477,7 +477,6 @@ namespace RPGMods.Hooks
 
     [HarmonyPatch(typeof(BuffSystem_Spawn_Server), nameof(BuffSystem_Spawn_Server.OnUpdate))]
     public class BuffSystem_Spawn_Server_Patch {
-        public static bool buffLogging = false;
         private static void Prefix(BuffSystem_Spawn_Server __instance)
         {
             if (PvPSystem.isPunishEnabled || SiegeSystem.isSiegeBuff || PermissionSystem.isVIPSystem || PvPSystem.isHonorSystemEnabled)
@@ -518,7 +517,6 @@ namespace RPGMods.Hooks
     [HarmonyPatch(typeof(BuffDebugSystem), nameof(BuffDebugSystem.OnUpdate))]
     public class DebugBuffSystem_Patch
     {
-        public static bool buffLogging = false;
         private static void Prefix(BuffDebugSystem __instance)
         {
             if (HunterHuntedSystem.isActive) {
@@ -545,13 +543,13 @@ namespace RPGMods.Hooks
                     // - Buff_OutOfCombat only seems to be sent once.
                     var inCombat = Cache.GetCombatStart(steamID) > Cache.GetCombatEnd(steamID);
                     if (combatStart && !inCombat) {
-                        if (buffLogging) Plugin.Logger.LogInfo($"{DateTime.Now}: {steamID}: Combat start");
+                        if (Helper.buffLogging) Plugin.Logger.LogInfo($"{DateTime.Now}: {steamID}: Combat start");
                         Cache.playerCombatStart[steamID] = DateTime.Now;
                         
                         // Actions to check on combat start
                         if (HunterHuntedSystem.isActive) HunterHuntedSystem.CheckForAmbush(userEntity, ownerEntity);
                     } else if (combatEnd) {
-                        if (buffLogging) Plugin.Logger.LogInfo($"{DateTime.Now}: {steamID}: Combat end");
+                        if (Helper.buffLogging) Plugin.Logger.LogInfo($"{DateTime.Now}: {steamID}: Combat end");
                         Cache.playerCombatEnd[steamID] = DateTime.Now;
                     }
                 }

--- a/Hooks/UnitSpawnerHook.cs
+++ b/Hooks/UnitSpawnerHook.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using ProjectM;
 using HarmonyLib;
+using ProjectM.Shared;
 using RPGMods.Utils;
-using RPGMods.Systems;
 
 namespace RPGMods.Hooks
 {
@@ -12,37 +12,64 @@ namespace RPGMods.Hooks
         public static bool listen = false;
         public static void Prefix(UnitSpawnerReactSystem __instance)
         {
-            //if (__instance.__OnUpdate_LambdaJob0_entityQuery != null)
             {
                 var entities = __instance.__OnUpdate_LambdaJob0_entityQuery.ToEntityArray(Unity.Collections.Allocator.Temp);
-                foreach (var entity in entities)
-                {
+                foreach (var entity in entities) {
+                    Plugin.Logger.LogInfo($"{DateTime.Now}: unit spawn {Helper.GetPrefabName(Helper.GetPrefabGUID(entity))}");
                     if (!__instance.EntityManager.HasComponent<LifeTime>(entity)) return;
 
-                    var Duration = __instance.EntityManager.GetComponentData<LifeTime>(entity).Duration;
-                    // If this successfully gets decoded, then this is a spawn from the HunterHuntedSystem
-                    // ... or just extremely lucky.
-                    if (HunterHuntedSystem.DecodeLifetime(Duration, out var level))
+                    var lifetime = __instance.EntityManager.GetComponentData<LifeTime>(entity);
+                    // If this successfully gets decoded, then this is a custom spawn... or just extremely lucky.
+                    if (SpawnUnit.DecodeLifetime(lifetime.Duration, out var level, out var faction))
                     {
-                        // Change faction to Vampire Hunters for spawned units
-                        var Faction = __instance.EntityManager.GetComponentData<FactionReference>(entity);
-                        Faction.FactionGuid = ModifiablePrefabGUID.Create(entity, __instance.EntityManager, new PrefabGUID((int)Prefabs.Faction.VampireHunters));
-                        __instance.EntityManager.SetComponentData(entity, Faction);
-                        // Set the spawned unit level to the provided level
-                        __instance.EntityManager.SetComponentData(entity, new UnitLevel() {Level = level});
+                        if (faction != SpawnUnit.SpawnFaction.Default) {
+                            // Change faction to Vampire Hunters for spawned units
+                            var Faction = __instance.EntityManager.GetComponentData<FactionReference>(entity);
+                            Faction.FactionGuid = ModifiablePrefabGUID.Create(entity, __instance.EntityManager, new PrefabGUID((int)Prefabs.Faction.VampireHunters));
+                            __instance.EntityManager.SetComponentData(entity, Faction);
+                        }
+                        if (level > 0) {
+                            // Set the spawned unit level to the provided level
+                            __instance.EntityManager.SetComponentData(entity, new UnitLevel() {Level = level});
+                        }
                     }
 
                     if (listen)
                     {
-                        if (Cache.spawnNPC_Listen.TryGetValue(Duration, out var Content))
+                        if (Cache.spawnNPC_Listen.TryGetValue(lifetime.Duration, out var Content))
                         {
                             Content.EntityIndex = entity.Index;
                             Content.EntityVersion = entity.Version;
                             if (Content.Options.Process) Content.Process = true;
 
-                            Cache.spawnNPC_Listen[Duration] = Content;
+                            Cache.spawnNPC_Listen[lifetime.Duration] = Content;
                             listen = false;
                         }
+                    }
+                }
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(MinionSpawnSystem), nameof(MinionSpawnSystem.OnUpdate))]
+    public static class MinionSpawnSystem_Patch {
+        public static void Prefix(MinionSpawnSystem __instance) {
+            var entities = __instance.__OnUpdate_LambdaJob0_entityQuery.ToEntityArray(Unity.Collections.Allocator.Temp);
+            foreach (var entity in entities) {
+                // Gloomrot spider tanks spawn a gloomrot techinician minion that does despawn when the spidertank gets
+                // by the "Lifetime" component. This will check for that case and destroy the minion on load so it doesn't get stuck.
+                // This does not impact the behaviour of the spiderbot (other than it does not drop the techician on death).
+                if (Helper.ConvertGuidToUnit(Helper.GetPrefabGUID(entity)) != Prefabs.Units.CHAR_Gloomrot_Technician) continue;
+                
+                if (__instance.EntityManager.TryGetComponentData(entity, out FactionReference faction)) {
+                    if (__instance.EntityManager.TryGetComponentData(entity, out EntityOwner eo)) {
+                         if (__instance.EntityManager.TryGetComponentData(eo.Owner, out LifeTime lt) && lt.EndAction != LifeTimeEndAction.Kill) {
+                             if (SpawnUnit.DecodeLifetime(lt.Duration, out _, out _)) {
+                                 // Destroy initial minions as they don't transition properly when their parent is destroyed without being killed.
+                                 DestroyUtility.CreateDestroyEvent(Plugin.Server.EntityManager, entity, DestroyReason.Default, DestroyDebugReason.ByScript);
+                                 DestroyUtility.Destroy(Plugin.Server.EntityManager, entity);
+                             }
+                         }
                     }
                 }
             }

--- a/Systems/ExperienceSystem.cs
+++ b/Systems/ExperienceSystem.cs
@@ -223,13 +223,14 @@ namespace RPGMods.Systems
             if (isGroup) {
                 xpGained = (int)(xpGained * GroupModifier);
             }
-            
-            Database.player_experience[ally.steamID] = Math.Max(ally.currentXp, 0) + xpGained;;
+
+            var newXp = Math.Max(ally.currentXp, 0) + xpGained;
+            Database.player_experience[ally.steamID] = newXp;
 
             if (Database.player_log_exp.TryGetValue(ally.steamID, out bool isLogging))
             {
                 if (isLogging) {
-                    GetLevelAndProgress(ally.currentXp, out int progress, out int earned, out int needed);
+                    GetLevelAndProgress(newXp, out int progress, out int earned, out int needed);
                     Output.SendLore(ally.userEntity, $"<color=#ffdd00>You gain {xpGained} XP by slaying a Lv.{mobLevel} enemy.</color> [ XP: <color=#fffffffe> {earned}</color>/<color=#fffffffe>{needed}</color> ]");
                 }
             }

--- a/Systems/HunterHuntedSystem.cs
+++ b/Systems/HunterHuntedSystem.cs
@@ -161,28 +161,6 @@ namespace RPGMods.Systems
             LogHeatData(heatData, userEntity, $"log({on})");
         }
 
-        // Encodes the unit level into the lifetime
-        // This uses the decimal portion of the float value to encode the value into the lifetime.
-        public static float EncodeLifetime(int level) {
-            level = Math.Clamp(level, 0, 99);
-            // Adds level and level "checksum" - this assumes a level cap of 99
-            return ambush_despawn_timer + (level / 100f) + (level / 10_000f);
-        }
-
-        // Decodes a unit level out of the lifetime
-        // Returns whether true if the level decodes correctly
-        public static bool DecodeLifetime(float lifetime, out int level) {
-            if (lifetime >= ambush_despawn_timer && lifetime < ambush_despawn_timer + 1) {
-                var encoded = (lifetime - ambush_despawn_timer) * 100;
-                // This works better than rounding as this value will always be slightly above the expected level due to the checksum
-                level = (int)encoded;
-                var levelChecksum = (int)Math.Round((encoded - level) * 100);
-                return level == levelChecksum;
-            }
-            level = 0;
-            return false;
-        }
-
         private static void HeatManager(Entity userEntity, out PlayerHeatData heatData, out ulong steamID) {
             steamID = entityManager.GetComponentData<User>(userEntity).PlatformId;
             var cooldownPerSecond = (double)heat_cooldown / 60;

--- a/Utils/FactionHeat.cs
+++ b/Utils/FactionHeat.cs
@@ -123,6 +123,6 @@ public static class FactionHeat {
         if (wantedLevel < 1) return;
         
         var squadMessage = SquadList.SpawnSquad(userEntity, playerEntity, faction, wantedLevel);
-        Output.SendLore(userEntity, $"<color=#{ColourGradient[wantedLevel]}>{squadMessage}</color>");
+        Output.SendLore(userEntity, $"<color=#{ColourGradient[wantedLevel - 1]}>{squadMessage}</color>");
     }
 }

--- a/Utils/Helper.cs
+++ b/Utils/Helper.cs
@@ -723,6 +723,11 @@ namespace RPGMods.Utils
             if (Enum.IsDefined(typeof(Prefabs.Faction), guid.GetHashCode())) return (Prefabs.Faction)guid.GetHashCode();
             return Prefabs.Faction.Unknown;
         }
+        
+        public static Prefabs.Units ConvertGuidToUnit(PrefabGUID guid) {
+            if (Enum.IsDefined(typeof(Prefabs.Units), guid.GetHashCode())) return (Prefabs.Units)guid.GetHashCode();
+            return Prefabs.Units.Unknown;
+        }
 
         /*
         public static void TeleportTo(Context ctx, float3 position)

--- a/Utils/Prefabs.cs
+++ b/Utils/Prefabs.cs
@@ -4,6 +4,7 @@
 // Thanks https://github.com/decaprime
 public static class Prefabs {
     public enum Units {
+        Unknown = 0,
         CHAR_ArchMage_FlameSphere = 2138173476,
         CHAR_ArchMage_Summon = 805231073,
         CHAR_ArchMage_VBlood = -2013903325,

--- a/Utils/SpawnUnit.cs
+++ b/Utils/SpawnUnit.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using ProjectM;
+using Unity.Entities;
+using Unity.Mathematics;
+
+namespace RPGMods.Utils; 
+
+public class SpawnUnit {
+    private static Entity emptyEntity = new();
+    public enum SpawnFaction {
+        Default = 0,
+        VampireHunters = 1,
+    }
+    // Encodes the unit level/faction into the lifetime
+    // Set faction/level to 0 to spawn the unit with the default faction/level
+    // Encoded as: 99F.LLCC
+    // where:
+    //    F = faction
+    //   LL = level
+    //   CC = checksum
+    // Note: Due to floats only providing up to 7 digits of info, this is the most we can encode into this value.
+    // Some edge cases occur, which are handled appropriately in the decode function.
+    public static float EncodeLifetime(int lifetime, int level, SpawnFaction faction) {
+        // Lifetime needs to be a multiple of 10 between 10 and 999 for the following code to work.
+        lifetime = Math.Clamp((lifetime / 10) * 10, 10, 1000);
+        // Faction needs to be between 0 and 9
+        var factionAsInt = Math.Clamp((int)faction, 0, 9);
+        // Level needs to be between 0 and 99
+        level = Math.Clamp(level, 0, 99);
+	
+        // Adds level and level "checksum" - this assumes a level cap of 99
+        var partFaction = factionAsInt; // section: 10X
+        var partLevel = level / 1_00f; // section: 100.XX
+        var partLevelChecksum = level / 1_00_00f; // section: 100.00XX
+        return lifetime + partFaction + partLevel + partLevelChecksum;
+    }
+
+    // Decodes a unit level/faction out of the lifetime duration.
+    // Returns whether true if the level decodes correctly
+    public static bool DecodeLifetime(float lifetime, out int level, out SpawnFaction faction) {
+        // Encoded as 99F.LLCC where:
+        // F = faction
+        // LL = level
+        // CC = level checksum
+	
+        // Get 1 digits for the faction
+        var encodedSection = lifetime % 10;
+        var decoded = (int)encodedSection;
+        faction = Enum.IsDefined(typeof(SpawnFaction), decoded) ? (SpawnFaction)decoded : SpawnFaction.Default;
+
+        // Get 2 digits for the level
+        encodedSection = (encodedSection % 1) * 100;
+        decoded = (int)encodedSection;
+        level = decoded;
+
+        // Get 2 digits for the level check
+        encodedSection = (encodedSection % 1) * 100;
+        // Need to round this one, as float inaccuracies creep in :(
+        var levelCheck = (int)Math.Round(encodedSection);
+	
+        // There are some edge cases that occur due to floating point implementation.
+        // This will clean those edge cases up.
+        if (levelCheck != level) {
+            switch (level) {
+                case 15:
+                case 40:
+                    levelCheck -= 1;
+                    break;
+                case 54:
+                    levelCheck += 1;
+                    break;
+            }
+        }
+
+        return levelCheck == level;
+    }
+
+    public static void Spawn(Prefabs.Units type, float3 position, int count, float minRange, float maxRange, float lifetime) {
+        Plugin.Server.GetExistingSystem<UnitSpawnerUpdateSystem>().SpawnUnit(
+            emptyEntity, new PrefabGUID((int)type), position, count, minRange, maxRange, lifetime);
+    }
+}

--- a/Utils/SquadList.cs
+++ b/Utils/SquadList.cs
@@ -12,7 +12,6 @@ namespace RPGMods.Utils {
     public static class SquadList {
 
         private static EntityManager entityManager = Plugin.Server.EntityManager;
-        private static Entity emptyEntity = new();
         private static Random generate = new();
         public static bool showDebugLogs = false;
 
@@ -245,10 +244,8 @@ namespace RPGMods.Utils {
 
             var position = entityManager.GetComponentData<LocalToWorld>(player).Position;
             foreach (var unit in squad.units) {
-                var lifetime = HunterHuntedSystem.EncodeLifetime(Math.Clamp(unit.level, 0, 99));
-                Plugin.Server.GetExistingSystem<UnitSpawnerUpdateSystem>().SpawnUnit(
-                    emptyEntity, new PrefabGUID((int)unit.type), position, unit.count, unit.range, unit.range + 4,
-                    lifetime);
+                var lifetime = SpawnUnit.EncodeLifetime((int)HunterHuntedSystem.ambush_despawn_timer, unit.level, SpawnUnit.SpawnFaction.VampireHunters);
+                SpawnUnit.Spawn(unit.type, position, unit.count, unit.range, unit.range + 4f, lifetime);
                 if (showDebugLogs) Plugin.Logger.LogWarning($"{DateTime.Now}: Spawning: {unit.count}*{unit.type}");
             }
 


### PR DESCRIPTION
When spawning spiderbot tanks as part of the gloomrot wanted faction, there is a set of circumstances* that the spiderbot will de-spawn and will leave the onboard technician in a bad state (where they cannot be interacted with).

This also provides a command as part of the wanted system to remove any existing technicians. Currently it also removes any other spawned minions, as there does not seem to be a _working_ mechanism to differentiate between the working units and the bad units.

*The specific circumstances are as follows:
- spawn spiderbot with a LifeTime component
- attack spiderbot
- wait for unit to be destroyed by the LifeTime
- see the technician drop off the spiderbot and be non-interactive